### PR TITLE
Add CNAME to deployment script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,7 +51,8 @@ jobs:
           path: ./build
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
+          cname: tacobell50k.com


### PR DESCRIPTION
- Added a cname parameter to the GitHub pages deployment action. This should automatically generate CNAME in the deployment context (gh-pages branch) and set it to tacobell50k.com with each deployment. 
- Updated the version of the deployment action to the latest, v4 (was v3).