### PR TITLE
2026 Registration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# GitHub Copilot Instructions for the Taco Bell 50k Project
+
+Welcome to the **Taco Bell 50k** React application! As GitHub Copilot, you should tailor your suggestions to the stack, patterns, and conventions used here.
+
+- You are an expert in React and TypeScript development.
+- You value code quality, readability, and maintainability.
+- You value consistency in your code and follow established patterns.
+- You strive for simplicity and avoid unnecessary complexity.
+- You are proactive in identifying and addressing potential issues.
+- You understand the importance of user experience and accessibility. Accessibility is especially important to you.
+- Comment your code generously. Explain both the "what" and the "why" behind your implementations. Comments should be understandable to developers senior in R Shiny development but with little experience in React or TypeScript.
+
+## Project Overview
+- A Create React App (TypeScript) single-page app.
+- Uses React Router for client-side navigation.
+- Forms use [Formspree](https://formspree.io/) plus `<useSubmit>` for submissions.
+- UI built with Fluent UI React Components (Inputs, Buttons, Toaster, Toasts).
+- State updates via Immer in controlled components.
+- Styling via `makeStyles` and inline style props for unique layouts.
+
+## Code Organization
+- **src/**
+  - `index.tsx` → React entry point.
+  - `App.tsx` → Top-level routes.
+  - **pages/** → Route views (Home, Register, Confirmation, NotFound).
+  - **components/** → Reusable pieces (Banner, Countdown, RegistrationForm, etc.).
+  - **types/** → Declarations (e.g. images.d.ts).
+- **public/** → Static assets and manifest.
+
+## Conventions & Patterns
+- **Component definitions**:  
+  `export const MyComponent: FC<Props> = ({ … }) => { … }`
+- **State**:  
+  - Hold a single `formData` object in RegistrationForm.  
+  - Update via `produce(current, draft => { draft.foo = value })`.
+- **Handlers**:  
+  - Use `useCallback<…>((_, { value }) => { … }, [ ])`.
+- **Form submission**:  
+  - Prevent default, call `submit(formData)`.  
+  - On success/error, dispatch Fluent UI Toasts and navigate via `useNavigate`.
+- **Styling**:  
+  - Prefer `makeStyles` for class-based styles.  
+  - Inline `style={…}` only for one-off layout tweaks.
+
+## TypeScript Guidance
+- Leverage strict types for props and form fields.
+- Import type-only symbols with `import type`.
+- Use union or literal types for props when appropriate.
+
+## Fluent UI Tips
+- Use `<Field label="…" required>` to group inputs.
+- Wrap toast messages in `<Toast><ToastTitle>…</ToastTitle></Toast>`.
+- Always include `<Toaster />` once per form.
+
+## Testing
+- Tests live alongside components (e.g. `App.test.tsx`).
+- Use `@testing-library/react` conventions.
+
+## When to Suggest
+- Generating new forms or inputs, follow the patterns above.
+- For new UI screens, set up routes in `App.tsx` and corresponding page in `pages/`.
+- Use existing components (Banner, Countdown) patterns for consistency.
+- Keep third-party integrations (Formspree, React Router) aligned.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/confirmation" element={<Confirmation />} />
-        <Route path="/register" element={<Register />} />
+        {/* Pass formspreeEndpoint prop to Register component */}
+        <Route path="/register" element={<Register formspreeEndpoint="myzgjwkp" />} />
         {/* Add a catch-all route for 404 Not Found */}
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,8 +58,19 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/confirmation" element={<Confirmation />} />
-        {/* Pass formspreeEndpoint prop to Register component */}
-        <Route path="/register" element={<Register formspreeEndpoint="myzgjwkp" />} />
+        {/* Pass formspreeEndpoint prop to Register component for 2025 */}
+        <Route
+          path="/register/2025"
+          element={<Register formspreeEndpoint="myzgjwkp" />}
+        />
+        {/* New registration route for 2026 */}
+        <Route
+          path="/register/2026"
+          element={
+            // TODO: replace with actual 2026 Formspree endpoint ID
+            <Register formspreeEndpoint="YOUR_2026_ENDPOINT_ID" />
+          }
+        />
         {/* Add a catch-all route for 404 Not Found */}
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
           path="/register/2026"
           element={
             // TODO: replace with actual 2026 Formspree endpoint ID
-            <Register formspreeEndpoint="YOUR_2026_ENDPOINT_ID" />
+            <Register formspreeEndpoint="mjkarnlz" />
           }
         />
         {/* Add a catch-all route for 404 Not Found */}

--- a/src/components/RegistrationFrom.tsx
+++ b/src/components/RegistrationFrom.tsx
@@ -39,9 +39,11 @@ type FormData = {
 
 type Props = {
   disabled?: boolean;
+  /** Formspree endpoint ID for useSubmit */
+  formspreeEndpoint: string;
 };
 
-export const RegistrationForm: FC<Props> = ({ disabled }) => {
+export const RegistrationForm: FC<Props> = ({ disabled, formspreeEndpoint }) => {
   const classes = useStyles();
   const navigate = useNavigate();
   const { dispatchToast } = useToastController();
@@ -58,7 +60,7 @@ export const RegistrationForm: FC<Props> = ({ disabled }) => {
     comments: "",
   });
 
-  const submit = useSubmit<FormData>("myzgjwkp", {
+  const submit = useSubmit<FormData>(formspreeEndpoint, {
     onError: () => {
       dispatchToast(
         <Toast

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -51,27 +51,28 @@ function Home() {
 
   // Component
   return (
-      <FluentProvider theme={lightTheme}>
-        <div>
-          <HeroBanner />
-          <Countdown />
-          <div className={classes.content}>
-            <RaceDescription />
-            <RaceDetails />
-            <Rules />
-            {/* <Videos /> */}
-            <Button onClick={handleGoToRegistration2025} appearance="primary" className={classes.registerButton}>
-              Register for 2025
-            </Button>
-            {/* New button for 2026 registration */}
-            <Button onClick={handleGoToRegistration2026} appearance="primary" className={classes.registerButton}>
-              Register for 2026
-            </Button>
-            <Donate />
-          </div>
+    <FluentProvider theme={lightTheme}>
+      <div>
+        <HeroBanner />
+        <Countdown />
+        <div className={classes.content}>
+          <RaceDescription />
+          <RaceDetails />
+          <Rules />
+          {/* <Videos /> */}
+          {/* Button for 2026 registration */}
+          <Button
+            onClick={handleGoToRegistration2026}
+            appearance="primary"
+            className={classes.registerButton}
+          >
+            Register for 2026
+          </Button>
+          <Donate />
         </div>
-      </FluentProvider>
-    );
+      </div>
+    </FluentProvider>
+  );
 }
 
 export default Home;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -42,9 +42,9 @@ function Home() {
   const navigate = useNavigate();
 
   // Handlers for year-specific registration
-  const handleGoToRegistration2025 = () => {
-    navigate("/register/2025", { preventScrollReset: false });
-  };
+  // const handleGoToRegistration2025 = () => {
+  //   navigate("/register/2025", { preventScrollReset: false });
+  // };
   const handleGoToRegistration2026 = () => {
     navigate("/register/2026", { preventScrollReset: false });
   };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -41,9 +41,12 @@ function Home() {
   const classes = useStyles();
   const navigate = useNavigate();
 
-  // Handlers
-  const handleGoToRegistration = () => {
-    navigate("/register", { preventScrollReset: false });
+  // Handlers for year-specific registration
+  const handleGoToRegistration2025 = () => {
+    navigate("/register/2025", { preventScrollReset: false });
+  };
+  const handleGoToRegistration2026 = () => {
+    navigate("/register/2026", { preventScrollReset: false });
   };
 
   // Component
@@ -57,7 +60,13 @@ function Home() {
             <RaceDetails />
             <Rules />
             {/* <Videos /> */}
-            <Button onClick={handleGoToRegistration} appearance="primary" className={classes.registerButton}>Register for 2025</Button>
+            <Button onClick={handleGoToRegistration2025} appearance="primary" className={classes.registerButton}>
+              Register for 2025
+            </Button>
+            {/* New button for 2026 registration */}
+            <Button onClick={handleGoToRegistration2026} appearance="primary" className={classes.registerButton}>
+              Register for 2026
+            </Button>
             <Donate />
           </div>
         </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -57,7 +57,7 @@ function Home() {
             <RaceDetails />
             <Rules />
             {/* <Videos /> */}
-            <Button onClick={handleGoToRegistration} appearance="primary" className={classes.registerButton}>Register</Button>
+            <Button onClick={handleGoToRegistration} appearance="primary" className={classes.registerButton}>Register for 2025</Button>
             <Donate />
           </div>
         </div>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -61,7 +61,6 @@ const Register: FC<RegisterProps> = ({ formspreeEndpoint }: RegisterProps) => {
          <div className={classes.background}>
            <div className={classes.content}>
              <img src={pintoBeanAwakens} alt="Taco Bell 50K unofficial logo. A cracked bell with the text 'the Pinto Bean Awakens'." className={classes.pintoBeanAwakens} />
--            <RegistrationForm formspreeEndpoint="myzgjwkp"/>
 +            <RegistrationForm formspreeEndpoint={formspreeEndpoint} />
            </div>
          </div>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -2,6 +2,7 @@ import {
   FluentProvider,
   makeStyles,
 } from "@fluentui/react-components";
+import { type FC } from 'react';
 
 import { RegistrationForm } from "../components/RegistrationFrom";
 
@@ -45,21 +46,27 @@ const useStyles = makeStyles({
   },
 });
 
-function Register() {
-  // Hooks
-  const classes = useStyles();
+// Add formspreeEndpoint prop to allow dynamic endpoint
+type RegisterProps = {
+  /** Formspree endpoint ID passed to RegistrationForm */
+  formspreeEndpoint: string;
+};
+const Register: FC<RegisterProps> = ({ formspreeEndpoint }: RegisterProps) => {
+   // Hooks
+   const classes = useStyles();
 
-  // Component
-  return (
-      <FluentProvider theme={lightTheme}>
-        <div className={classes.background}>
-          <div className={classes.content}>
-            <img src={pintoBeanAwakens} alt="Taco Bell 50K unofficial logo. A cracked bell with the text 'the Pinto Bean Awakens'." className={classes.pintoBeanAwakens} />
-            <RegistrationForm />
-          </div>
-        </div>
-      </FluentProvider>
-    );
-}
+   // Component
+   return (
+       <FluentProvider theme={lightTheme}>
+         <div className={classes.background}>
+           <div className={classes.content}>
+             <img src={pintoBeanAwakens} alt="Taco Bell 50K unofficial logo. A cracked bell with the text 'the Pinto Bean Awakens'." className={classes.pintoBeanAwakens} />
+-            <RegistrationForm formspreeEndpoint="myzgjwkp"/>
++            <RegistrationForm formspreeEndpoint={formspreeEndpoint} />
+           </div>
+         </div>
+       </FluentProvider>
+     );
+};
 
 export default Register;


### PR DESCRIPTION
- Page now has a "register for 2026" button that routes form submissions to the proper form on FormSpree.
- The Formspree endpoint has been functionalized as a prop to the Registration component, making it easier to update the form endpoint. This also makes it possible to have multiple regisration pages at once (for example 2026 and 2027) routing to different forms, without having to duplicate the registration page code.