### PR TITLE
Reset start date and countdown timer for 2026

### DIFF
--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import { DateTime, Interval } from "luxon";
 import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
 
-const start = DateTime.local(2025, 10, 4, 7, 0, 0, { zone: "America/Denver" });
+// Countdown target: Saturday, October 3rd, 2026 at 7:30 AM America/Denver
+const start = DateTime.local(2026, 10, 3, 7, 30, 0, { zone: "America/Denver" });
 
 const leadingZero = (value: number) => {
   return value < 10 ? `0${value}` : value;

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -39,7 +39,7 @@ export const RaceDetails = () => {
       <div className="details-container">
         <div className="detail">
           <h3>Date</h3>
-          <p>Saturday, October 4th, 2025</p>
+          <p>Saturday, October 3rd, 2026</p>
         </div>
         <div className="detail">
           <h3>Start Time</h3>


### PR DESCRIPTION
Re-set the countdown timer and changed the start date/time of the race to October 3rd, 2026, 7:30am MT.