### PR TITLE
Update Name for 2026

### DIFF
--- a/src/components/Description.tsx
+++ b/src/components/Description.tsx
@@ -1,17 +1,17 @@
 export const RaceDescription = () => {
   return (
     <section className="race-description">
-      <h2>The 8th edition of the International Taco Bell 50k Ultramarathon</h2>
+      <h2>The Loco Strikes Back: 9th Edition of the International Taco Bell 50k Ultramarathon</h2>
       <p>
         It has been described as Urban Legend. More mysterious and barking
         spiders than the Barkley Marathons. The International Taco Bell 50k
-        boasts a higher DNF rate than the famed Leadville 100 Trail Race. The
-        lore of the genesis for the race dates back to a hot tub, stoic Russian,
-        short king from New York and Susie. The race has been held annually in
-        Denver, Colorado in early October, which coincidentally coincides with
-        International Taco Day. It is a good idea to engage in gastric training.
-        If you complete the challenge, you will be deemed a SURVIVOR, revered
-        and heckled for life!
+        boasts a higher DNF rate than the famed Leadville 100 Trail Race.
+        According to legend, the race began with a hot tub, a stoic Russian,
+        a short king from New York, and Susie. The race has been held annually
+        in Denver, Colorado in early October, which coincidentally coincides
+        with International Taco Day. It is a good idea to engage in gastric
+        training. If you complete the challenge, you will be deemed a SURVIVOR,
+        revered and heckled for life!
       </p>
       
     </section>

--- a/src/components/Description.tsx
+++ b/src/components/Description.tsx
@@ -6,7 +6,7 @@ export const RaceDescription = () => {
         It has been described as Urban Legend. More mysterious and barking
         spiders than the Barkley Marathons. The International Taco Bell 50k
         boasts a higher DNF rate than the famed Leadville 100 Trail Race.
-        According to legend, the race began with a hot tub, a stoic Russian,
+        As the tale is told, the race began with a hot tub, a stoic Russian,
         a short king from New York, and Susie. The race has been held annually
         in Denver, Colorado in early October, which coincidentally coincides
         with International Taco Day. It is a good idea to engage in gastric


### PR DESCRIPTION
Content updates:

* Added the race title for the 2026 edition of the TB50K. The event title in the `<h2>` header was updated to "The Loco Strikes Back: 9th Edition of the International Taco Bell 50k Ultramarathon".
* Minor word choice changes to the race origin story, to boost the rhetorical effect. Long live the short king!